### PR TITLE
[#55484066] sneha/dancarley Nginx security for mirror

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -9,11 +9,17 @@ classes:
   - nginx
 
 nginx::nginx_vhosts:
+  default_server:
+    www_root: '/usr/share/nginx/html'
+    listen_options: 'default_server'
+    location_cfg_prepend:
+      return: '444 "no content"'
   'www-origin':
     server_name:
       - 'www-origin.mirror.*'
     www_root: '/srv/mirror_data/www-origin'
-
+nginx::server_tokens: 'off'
+nginx::confd_purge: true
 puppet::puppet_ensure: '3.2.3-1puppetlabs1'
 puppet::facter_ensure: '1.7.2-1puppetlabs1'
 
@@ -27,7 +33,7 @@ mirror_environment::package_array:
 
 gds_sudo::sudoers:
   group_sudo:
-    users: %sudo
+    users: '%sudo'
     tags: 
       - 'NOPASSWD'
 


### PR DESCRIPTION
Disabled the server tokens, so that we do not expose the nginx version
to end user.
Returning 444 - no content if someone hits url other than mirror url
