### PR TITLE
[#55632912] using rssh to restrict user to rsync

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -3,6 +3,7 @@ forge 'http://forge.puppetlabs.com/'
 mod 'puppetlabs/stdlib', '~> 3.0'
 mod 'attachmentgenie/ufw', '1.1.0'
 mod 'attachmentgenie/ssh', '1.1.1'
+mod 'blom/rssh'
 
 mod 'nginx',
   :git => 'git://github.com/alphagov/puppet-nginx-jfryman.git',

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -12,6 +12,7 @@ FORGE
       puppetlabs/stdlib (>= 2.2.1)
     attachmentgenie/ufw (1.1.0)
       puppetlabs/stdlib (>= 2.2.1)
+    blom/rssh (0.0.3)
     puppetlabs/apt (1.2.0)
       puppetlabs/stdlib (>= 2.2.1)
     puppetlabs/stdlib (3.2.0)
@@ -73,6 +74,7 @@ GIT
 DEPENDENCIES
   attachmentgenie/ssh (= 1.1.1)
   attachmentgenie/ufw (= 1.1.0)
+  blom/rssh (>= 0)
   ext4mount (>= 0)
   fail2ban (>= 0)
   gds_accounts (>= 0)

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -12,6 +12,7 @@ classes:
   - mirror_environment::firewall
   - mirror_environment::mounts
   - mirror_environment::user
+  - rssh
 
 puppet::puppet_ensure: '3.2.3-1puppetlabs1'
 puppet::facter_ensure: '1.7.2-1puppetlabs1'
@@ -20,6 +21,9 @@ mirror_environment::package_array:
   - lvm2
   - rsync
   - curl
+
+rssh::users:
+  - 'mirror-rsync:022:100000'
 
 nginx::server_tokens: 'off'
 nginx::confd_purge: true

--- a/modules/mirror_environment/manifests/user.pp
+++ b/modules/mirror_environment/manifests/user.pp
@@ -18,5 +18,6 @@ class mirror_environment::user (
   account { $username:
     ssh_key => $ssh_key,
     comment => 'Mirror user which rsynchs data',
+    shell   => '/usr/bin/rssh',
   }
 }


### PR DESCRIPTION
Added puppet-forge module rssh. We evaluated other options like ssh
authorize keys and rrsync. But rssh seems to be the better one.
Overiding user shell to rssh shell and allowing only rsync acess
