### PR TITLE
[#55707982] default vhost nginx for ssl

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -24,11 +24,6 @@ mirror_environment::package_array:
 nginx::server_tokens: 'off'
 nginx::confd_purge: true
 nginx::nginx_vhosts:
-  default_server:
-    www_root: '/usr/share/nginx/html'
-    listen_options: 'default_server'
-    location_cfg_prepend:
-      return: '444 "no content"'
   'www-origin':
     server_name:
       - 'www-origin.mirror.*'

--- a/modules/mirror_environment/manifests/init.pp
+++ b/modules/mirror_environment/manifests/init.pp
@@ -30,4 +30,21 @@ class mirror_environment (
   validate_hash($ssl_config)
   create_resources('mirror_environment::nginx_ssl', $ssl_config)
 
+  package{ 'ssl-cert':
+    ensure => present,
+  } ->
+  file{ '/etc/ssl/private/ssl-cert-snakeoil.key': } ->
+  file{ '/etc/ssl/certs/ssl-cert-snakeoil.pem': }
+
+  nginx::resource::vhost{ 'default_server':
+      www_root             => '/usr/share/nginx/html',
+      listen_options       => ' default_server',
+      location_cfg_prepend =>  {
+        'return' => '444 "no content"',
+      },
+      ssl                  => true,
+      ssl_key              => '/etc/ssl/private/ssl-cert-snakeoil.key',
+      ssl_cert             => '/etc/ssl/certs/ssl-cert-snakeoil.pem',
+  }
+
 }


### PR DESCRIPTION
installing the ssl-cert which provides dummy ssl certificates for
nginx.

Using manifest to add vhost instead of hieradata. This is because the
certificates are created by ssl-cert pkg. So it is required to install
ssl-cert package first and then creating cert/key files resources and
creating nginx vhost. We are maintaining this order in manifest file.

Also nginx-puppet module has bug when we use ssl and listen options
together. We fixed this by putting a space infront of default vhost :-O
