### PR TITLE
[#54676640] removed listener to port 80.

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -37,6 +37,7 @@ nginx::nginx_vhosts:
     server_name:
       - 'www-origin.mirror.*'
     www_root: '/srv/mirror_data/www-origin'
+    listen_port: 443
     ssl:      true
     ssl_key:  '/etc/nginx/ssl/www-origin.key'
     ssl_cert: '/etc/nginx/ssl/www-origin.cert'


### PR DESCRIPTION
puppet-nginx module compares the listen_port with ssl_port if it finds
them same. it uses ssl only.
