### PR TITLE
[#56716202] Enable unattended upgrades

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,6 +1,7 @@
 forge 'http://forge.puppetlabs.com/'
 
 mod 'puppetlabs/stdlib', '~> 3.0'
+mod 'puppetlabs/apt', '~> 1.3.0'
 mod 'arnoudj/sudo'
 mod 'attachmentgenie/ufw', '1.1.0'
 mod 'attachmentgenie/ssh', '1.1.1'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -14,7 +14,7 @@ FORGE
     attachmentgenie/ufw (1.1.0)
       puppetlabs/stdlib (>= 2.2.1)
     blom/rssh (0.0.3)
-    puppetlabs/apt (1.2.0)
+    puppetlabs/apt (1.3.0)
       puppetlabs/stdlib (>= 2.2.1)
     puppetlabs/stdlib (3.2.0)
 
@@ -93,5 +93,6 @@ DEPENDENCIES
   harden (>= 0)
   nginx (>= 0)
   puppet (>= 0)
+  puppetlabs/apt (~> 1.3.0)
   puppetlabs/stdlib (~> 3.0)
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,5 +1,6 @@
 ---
 classes:
+  - apt::unattended_upgrades
   - fail2ban
   - gds_accounts
   - harden


### PR DESCRIPTION
Using new support in upstream apt module. The `mail_to` param will only be
set for production so as to prevent us getting spammed about Vagrant nodes
that we don't really care about. Done in:

gds/govuk_mirror-deployment@2fab191df0c96868e2c5397b181e891f155c65ba
