### PR TITLE
Only cache mirrored content for 15m

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -43,6 +43,7 @@ nginx::nginx_vhosts:
     ssl_key:  '/etc/nginx/ssl/www-origin.key'
     ssl_cert: '/etc/nginx/ssl/www-origin.cert'
     location_cfg_prepend:
+      expires: '15m'
       error_page: '403 500 503 504 =503 /error/503.html'
     try_files:
       - '$uri/index.html'


### PR DESCRIPTION
This will prevent the CDN from holding onto content that could be up to
24hrs out of date.

There is a toss-up about whether this would be better applied here or within
the CDN configs. Arguably it is more "obvious" in the CDN config, if applied
within the condition that fails over, however it's more complicated to do
and might be troublesome when we have more than one CDN.

/cc @rjw1 @samjsharpe @annashipman 
