### PR TITLE
Switch to librarian-puppet-maestrodev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.1.0'
 gem 'facter', ENV['FACTER_VERSION'] || '~> 1.6.0'
 
 # Dependency management.
-gem 'librarian-puppet', '~> 0.9.0'
+gem 'librarian-puppet-maestrodev'
 
 # Testing utilities.
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,11 +5,15 @@ GEM
     facter (1.6.18)
     hiera (1.2.1)
       json_pure
+    highline (1.6.20)
     json (1.8.0)
     json_pure (1.8.0)
-    librarian-puppet (0.9.9)
-      json
+    librarian (0.1.1)
+      highline
       thor (~> 0.15)
+    librarian-puppet-maestrodev (0.9.10.1)
+      json
+      librarian (>= 0.1.1)
     metaclass (0.0.1)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
@@ -43,7 +47,7 @@ PLATFORMS
 
 DEPENDENCIES
   facter (~> 1.6.0)
-  librarian-puppet (~> 0.9.0)
+  librarian-puppet-maestrodev
   puppet (~> 3.1.0)
   puppet-lint (~> 0.3.0)
   puppet-syntax


### PR DESCRIPTION
Fixes module pinning for Forge modules. Per gds/puppet#953

I suspect that this will fix the following error, almost certainly caused by
pulling in a different version of the apt module:

```
Warning: Scope(Class[Apt::Update]): Could not look up qualified variable 'apt::update_timeout'; class apt has not been evaluated
```
