### PR TITLE
[#63525598] Enable whitelisting for fail2ban

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,7 +1,6 @@
 ---
 classes:
   - apt::unattended_upgrades
-  - fail2ban
   - gds_accounts
   - harden
   - puppet
@@ -10,6 +9,7 @@ classes:
   - gds_sudo
   - nginx
   - mirror_environment
+  - mirror_environment::fail2ban
   - mirror_environment::firewall
   - mirror_environment::mounts
   - mirror_environment::user

--- a/modules/mirror_environment/manifests/fail2ban.pp
+++ b/modules/mirror_environment/manifests/fail2ban.pp
@@ -1,0 +1,20 @@
+# == Class: mirror_environment::fail2ban
+#
+# Installs fail2ban for IP blacklisting
+#
+class mirror_environment::fail2ban (
+  $whitelist_ips = ['127.0.0.1'],
+) {
+  include ::fail2ban
+
+  file { '/etc/fail2ban/jail.local':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('mirror_environment/etc/fail2ban/jail.local.erb'),
+    notify  => Service['fail2ban'],
+    # Require package rather than class to avoid dependency issues
+    # incurred by the Fail2Ban module we are using.
+    require => Package['fail2ban'],
+  }
+}

--- a/modules/mirror_environment/templates/etc/fail2ban/jail.local.erb
+++ b/modules/mirror_environment/templates/etc/fail2ban/jail.local.erb
@@ -1,0 +1,8 @@
+# This file is managed by Puppet
+# Fail2Ban configuration file, overrides options set in jail.conf
+
+[DEFAULT]
+# "ignoreip" can be an IP address, a CIDR mask or a DNS host. Fail2ban
+# will not ban a host which matches an address in this list. Several
+# addresses can be defined using space separator.
+ignoreip = <%= @whitelist_ips.join(" ") %>


### PR DESCRIPTION
Add mirror_environment::fail2ban class to allow configuration of fail2ban using jail.local.

Aimed at whitelisting our own IP addresses to prevent us from blocking ourselves during testing.
