### PR TITLE
[#64726964] Enable `domain`-specific YAML in hiera

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,5 +1,6 @@
 :hierarchy:
   - "node.%{::clientcert}"
+  - "domain.%{::domain}"
   - "env.%{::environment}"
   - common
 :backends:


### PR DESCRIPTION
Allows us to specify hiera values per set of mirrors.

Useful in the first instance to define one SSL certificate for
*.mirror.provider0.production.govuk.service.gov.uk and another for
*.mirror.provider1.production.govuk.service.gov.uk.
