### PR TITLE
Rewrite trailing slashes to canonical URL

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -45,7 +45,7 @@ nginx::nginx_vhosts:
     location_cfg_prepend:
       expires: '15m'
       error_page: '403 500 503 504 =503 /error/503.html'
-      rewrite: '^/(.*)/$ https://www.gov.uk/$1 permanent;'
+      rewrite: '^/(.*)/$ https://www.gov.uk/$1 permanent'
     try_files:
       - '$uri/index.html'
       - '$uri.html'


### PR DESCRIPTION
If user hits https://www.gov.uk/browse/driving/, it redirects to https://www.gov.uk/browse/driving and does load the correct page.

Currently on mirror, we get a 503 in above scenario, because the redirection is usually handled by the application.

This commit adds a rewrite which will do that redirection for all URLs ending in a slash - I've confirmed that we don't have any URLs which should end in a trailing slash, so this change will make the mirror match the behaviour of the GOV.UK Stack.

This [Fixes #56337502] once it has been deployed
