### PR TITLE
Install Trusty HWE kernel

### DIFF
--- a/modules/mirror_environment/manifests/init.pp
+++ b/modules/mirror_environment/manifests/init.pp
@@ -48,15 +48,7 @@ class mirror_environment (
   }
 
   # Install Trusty HWE kernel
-  if ($::hostname == 'mirror0.mirror.provider0.production.govuk.service.gov.uk') {
-    package { 'update-manager-core':
-      ensure => present,
-    }
     package { ['linux-generic-lts-trusty', 'linux-image-generic-lts-trusty']:
       ensure  => present,
-      require => Package['update-manage-core'],
-      unless  => '/usr/bin/hwe-support-status',
     }
-  }
-
 }


### PR DESCRIPTION
The version of the Ubuntu kernel we're currently using EOL'd on August 4th.
This means that whilst we might still receive updates for software installed
on the machine, we won't receive any security updates etc. for the kernel,
which is a bad thing. To combat this, this commit installs the Trusty HWE kernel.

In addition, to ensure the bootstrap script can run successfully, this pull request
introduces changes to `sudoers`, which bring it in line with our production stack.
