### PR TITLE
Add .puppet-lintrc

### DIFF
--- a/.puppet-lintrc
+++ b/.puppet-lintrc
@@ -1,0 +1,1 @@
+--no-80chars-check


### PR DESCRIPTION
This project never had one, therefore adding one. `--no-80-chars-check` stops puppet-lint failing when there is more than eighty characters per line.
