### PR TITLE
Allow vagrant user to preserve the environment

### DIFF
--- a/modules/gds_sudo/files/sudoers.conf
+++ b/modules/gds_sudo/files/sudoers.conf
@@ -3,7 +3,7 @@
 # See the man page for details on how to write a sudoers file.
 # Defaults
 
-Defaults        !lecture,tty_tickets,!fqdn
+Defaults        !lecture,tty_tickets,!fqdn,env_reset,setenv
 
 # Uncomment to allow members of group sudo to not need a password
 # %sudo ALL=NOPASSWD: ALL


### PR DESCRIPTION
Vagrant derives it's privileges by membership of the %sudo group.
However the defaults for sudo don't include env_reset (which executes
commands in a minimal shell environment by default) or setenv (which
allows users to override env_reset if neccessary), which causes
reprovisioning a Vagrant machine to fail.

We should stop doing that.
