### PR TITLE
Enable HWE support

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -14,6 +14,7 @@ classes:
   - mirror_environment::mounts
   - mirror_environment::user
   - mirror_environment::clamdscan
+  - mirror_environment::supported_kernel
   - rssh
   - clamav
 
@@ -51,6 +52,8 @@ nginx::nginx_vhosts:
       - '$uri.html'
       - '$uri'
       - '=503'
+
+mirror_environment::supported_kernel::hwe_ver: 'trusty'
 
 mirror_environment::mounts::mirror_data: '/srv/mirror_data'
 mirror_environment::mounts::www_roots:

--- a/modules/mirror_environment/manifests/supported_kernel.pp
+++ b/modules/mirror_environment/manifests/supported_kernel.pp
@@ -1,0 +1,15 @@
+# A class to install supported kernels based on a Hiera key
+
+class mirror_environment::supported_kernel (
+  $hwe_ver,
+) {
+    if ($hwe_ver){
+      # Install HWE kernel. Version specified in Hiera.
+        package {[
+          "linux-generic-lts-${hwe_ver}",
+          "linux-image-generic-lts-${hwe_ver}",
+        ]:
+          ensure => present,
+        }
+      }
+  }


### PR DESCRIPTION
The GOV.UK mirrors run Ubuntu 12.04 (Precise), for which the kernel has now EOL'd. Ubuntu's [workaround](https://wiki.ubuntu.com/1204_HWE_EOL) for this allows hardware support to be brought forward from a later release (in this case, 14.04 (Trusty)), and thus make the installed kernel supported for a longer period of time.

At some stage, we might want to look at upgrading these to Trusty.
