### PR TITLE
Use govuk vagrant image with correct kernel

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,8 @@ node_defaults = {
 }
 
 Vagrant.configure("2") do |config|
-  config.vm.box     = "puppet-precise64"
-  config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-1204-x64.box"
+  config.vm.box     = "govuk_dev_precise64_20140829"
+  config.vm.box_url = "http://gds-boxes.s3.amazonaws.com/govuk_dev_precise64_20140829.box"
 
   config.vm.provision :shell,
     :inline => 'exec /vagrant/tools/bootstrap'


### PR DESCRIPTION
This moves to using the same Vagrant box version as we use elsewhere. I have picked the latest version which has the lts-trusty kernel we would like.
