### PR TITLE
Disable SSLv3

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -44,6 +44,7 @@ nginx::nginx_vhosts:
     ssl:      true
     ssl_key:  '/etc/nginx/ssl/www-origin.key'
     ssl_cert: '/etc/nginx/ssl/www-origin.cert'
+    ssl_protocols: 'TLSv1 TLSv1.1 TLSv1.2'
     location_cfg_prepend:
       expires: '15m'
       error_page: '403 500 503 504 =503 /error/503.html'


### PR DESCRIPTION
SSLv3 is fundamentally flawed, per the POODLE design flaw recently announced 
by Google. Disable SSLv3 to force communication at TLS only.
