### PR TITLE
Define SSL protocols to disable SSLv3

### DIFF
--- a/modules/mirror_environment/manifests/init.pp
+++ b/modules/mirror_environment/manifests/init.pp
@@ -45,6 +45,7 @@ class mirror_environment (
       ssl                  => true,
       ssl_key              => '/etc/ssl/private/ssl-cert-snakeoil.key',
       ssl_cert             => '/etc/ssl/certs/ssl-cert-snakeoil.pem',
+      ssl_protocols        => 'TLSv1, TLSv1.1, TLSv1.2',
   }
 
 }


### PR DESCRIPTION
We don't use the default_server server block in the Nginx configuration on the
mirrors, but we don't yet want to remove it. A story is going in the WebOps
backlog to look at doing that.

Even though we disable SSLv3 for the server block we do use
(www-origin.mirror.*), this won't actually stop the mirror machines from 
responding to requests with SSLv3. This is because, as at least one server 
block will respond to SSLv3 requests, Nginx needs to accept the connection and
decrypt it before it is able to work out which server block the request is
intended for.

By this point, Nginx will have accepted the connection, so we would still be 
vulnerable to the POODLE SSLv3 exploit.

In order to stop this, we're specifying the SSL protocols using the relevant
paramater of the Nginx module we use. In testing, this stops SSLv3 connections
being accepted.
