### PR TITLE
Remove commas

### DIFF
--- a/modules/mirror_environment/manifests/init.pp
+++ b/modules/mirror_environment/manifests/init.pp
@@ -45,7 +45,7 @@ class mirror_environment (
       ssl                  => true,
       ssl_key              => '/etc/ssl/private/ssl-cert-snakeoil.key',
       ssl_cert             => '/etc/ssl/certs/ssl-cert-snakeoil.pem',
-      ssl_protocols        => 'TLSv1, TLSv1.1, TLSv1.2',
+      ssl_protocols        => 'TLSv1 TLSv1.1 TLSv1.2',
   }
 
 }


### PR DESCRIPTION
Nginx config doesn't like commas, so remove them. If they're there, then the 
Nginx configuration fails to load on reboot.
