### PR TITLE
[#58334884] Add Nginx virtual host to serve assets from our mirrors

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -44,7 +44,7 @@ nginx::nginx_vhosts:
   'www-origin':
     server_name:
       - 'www-origin.mirror.*'
-    www_root: '/srv/mirror_data/www-origin'
+    www_root: '/srv/mirror_data/www.gov.uk'
     listen_port: 443
     ssl:      true
     ssl_key:  '/etc/nginx/ssl/www-origin.key'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -47,8 +47,8 @@ nginx::nginx_vhosts:
     www_root: '/srv/mirror_data/www.gov.uk'
     listen_port: 443
     ssl:      true
-    ssl_key:  '/etc/nginx/ssl/www-origin.key'
-    ssl_cert: '/etc/nginx/ssl/www-origin.cert'
+    ssl_key:  '/etc/nginx/ssl/mirror.key'
+    ssl_cert: '/etc/nginx/ssl/mirror.cert'
     ssl_protocols: 'TLSv1 TLSv1.1 TLSv1.2'
     location_cfg_prepend:
       expires: '15m'
@@ -65,8 +65,8 @@ nginx::nginx_vhosts:
     www_root: '/srv/mirror_data/assets.digital.cabinet-office.gov.uk'
     listen_port: 443
     ssl:  true
-    ssl_key: '/etc/nginx/ssl/www-origin.key'
-    ssl_cert: '/etc/nginx/ssl/www-origin.cert'
+    ssl_key: '/etc/nginx/ssl/mirror.key'
+    ssl_cert: '/etc/nginx/ssl/mirror.cert'
     ssl_protocols: 'TLSv1 TLSv1.1 TLSv1.2'
     location_cfg_prepend:
       expires: '15m'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -59,6 +59,21 @@ nginx::nginx_vhosts:
       - '$uri.html'
       - '$uri'
       - '=503'
+  'assets-origin':
+    server_name:
+      - 'assets-origin.mirror.*'
+    www_root: '/srv/mirror_data/assets.digital.cabinet-office.gov.uk'
+    listen_port: 443
+    ssl:  true
+    ssl_key: '/etc/nginx/ssl/www-origin.key'
+    ssl_cert: '/etc/nginx/ssl/www-origin.cert'
+    ssl_protocols: 'TLSv1 TLSv1.1 TLSv1.2'
+    location_cfg_prepend:
+      expires: '15m'
+      error_page: '403 500 503 504 =503 /error/503.html'
+    try_files:
+      - '$uri'
+      - '=503'
 
 mirror_environment::supported_kernel::hwe_ver: 'trusty'
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -78,8 +78,6 @@ nginx::nginx_vhosts:
 mirror_environment::supported_kernel::hwe_ver: 'trusty'
 
 mirror_environment::mounts::mirror_data: '/srv/mirror_data'
-mirror_environment::mounts::www_roots:
-  - '/srv/mirror_data/www-origin'
 mirror_environment::mounts::username: 'mirror-rsync'
 
 mirror_environment::user::username: 'mirror-rsync'

--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -4,7 +4,7 @@ gds_accounts::purge_ignore:
   - 'vboxadd'
 
 mirror_environment::ssl_config:
-  'www-origin':
+  'mirror':
     key:  |
       -----BEGIN RSA PRIVATE KEY-----
       MIICXQIBAAKBgQDKUzL5UtUwQp4Y45CHZVrwtKiAALidlWahTHGRcOob/y3hUt58

--- a/modules/mirror_environment/manifests/init.pp
+++ b/modules/mirror_environment/manifests/init.pp
@@ -30,6 +30,14 @@ class mirror_environment (
   validate_hash($ssl_config)
   create_resources('mirror_environment::nginx_ssl', $ssl_config)
 
+  # FIXME Remove once deployed
+  exec { 'Rename wildcard SSL certificate':
+    command => 'mv /etc/nginx/ssl/{www-origin,mirror}.cert;
+      mv /etc/nginx/ssl/{www-origin,mirror}.key',
+    onlyif  => 'test -f /etc/nginx/ssl/www-origin.cert',
+    before  => Class['nginx'],
+  }
+
   package{ 'ssl-cert':
     ensure => present,
   } ->

--- a/modules/mirror_environment/manifests/mounts.pp
+++ b/modules/mirror_environment/manifests/mounts.pp
@@ -2,7 +2,7 @@
 #
 # Configures LVM disks and mounts them
 #
-# === parameters
+# === Parameters
 #
 # [*mirror_data*]
 #   Root directory for the mounted disk

--- a/modules/mirror_environment/manifests/mounts.pp
+++ b/modules/mirror_environment/manifests/mounts.pp
@@ -20,7 +20,7 @@ class mirror_environment::mounts (
       mountoptions => 'defaults',
       disk         => '/dev/mapper/mirror-data',
       before       => File[$mirror_data],
-      require      => Lvm::Volume['data'],
+      require      => [Lvm::Volume['data'], File[$mirror_data]],
     }
 
     lvm::volume { 'data':

--- a/modules/mirror_environment/manifests/mounts.pp
+++ b/modules/mirror_environment/manifests/mounts.pp
@@ -1,7 +1,6 @@
 # == Class: mirror_environment::mounts
 #
-# Configures LVM disks, mounts them and ensures the mirror_data and
-# www_roots exist
+# Configures LVM disks and mounts them
 #
 # === parameters
 #
@@ -11,13 +10,9 @@
 # [*username*]
 #  Owner of the data directory and sub directories
 #
-# [*www_roots*]
-#   WWW root directories to have their existance ensured
-#
 class mirror_environment::mounts (
   $mirror_data,
   $username,
-  $www_roots = [],
 ) {
 
   if ($::environment != 'development') {
@@ -40,12 +35,4 @@ class mirror_environment::mounts (
     ensure => directory,
     owner  => $username,
   }
-
-  if ( $www_roots != [] ) {
-    file { $www_roots:
-      ensure => directory,
-      owner  => $username,
-    }
-  }
-
 }


### PR DESCRIPTION
In order to serve mirrored assets we need an nginx vhost to listen
on assets-origin.mirror.*.

Also, change the root public directory for the www-origin Nginx virtual host
to use the www.gov.uk hostname.

This is to accommodate changes that we're making to the GOV.UK Crawler
Worker to write content in directories named after the HTTP host from
which they were crawled.