### PR TITLE
Remove require in mount on file resource

### DIFF
--- a/modules/mirror_environment/manifests/mounts.pp
+++ b/modules/mirror_environment/manifests/mounts.pp
@@ -20,7 +20,7 @@ class mirror_environment::mounts (
       mountoptions => 'defaults',
       disk         => '/dev/mapper/mirror-data',
       before       => File[$mirror_data],
-      require      => [Lvm::Volume['data'], File[$mirror_data]],
+      require      => Lvm::Volume['data'],
     }
 
     lvm::volume { 'data':


### PR DESCRIPTION
Requiring `File[$mirror_data]` causes a circular dependency:

  (Exec[create-/srv/mirror_data] => Ext4mount[/srv/mirror_data] => File[/srv/mirror_data] => Ext4mount[/srv/mirror_data] => Exec[create-/srv/mirror_data])

There's no need to ensure that the directory is there before calling
ext4mount as ext4mount already creates the directory:

https://github.com/alphagov/puppet-ext4mount/blob/d97f99cc2801b83152b905d1285fa34e689cb499/manifests/init.pp#L24-L27

We still need the file resource, however, to ensure the directory owner
is set correctly.