### PR TITLE
[#58334980] Add /__canary__ healthcheck endpoint to mirrors

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -75,6 +75,16 @@ nginx::nginx_vhosts:
       - '$uri'
       - '=503'
 
+nginx::nginx_locations:
+  'canary':
+    vhost: 'assets-origin'
+    priority: 900
+    location: /__canary__
+    location_custom_cfg:
+      - 'default_type text/plain'
+      - 'add_header cache-control "max-age=0, no-store, no-cache"'
+      - 'return 200 "OK\n"'
+
 mirror_environment::supported_kernel::hwe_ver: 'trusty'
 
 mirror_environment::mounts::mirror_data: '/srv/mirror_data'


### PR DESCRIPTION
Add a healthcheck endpoint at `/__canary__` that can be used by Fastly's
backend probes to check that the mirror servers are healthy.

Returns a synthetic "OK" response with a HTTP 200 status.

```bash
vagrant@mirror0:~$ curl -kH 'Host:assets-origin.mirror.*' https://localhost/__canary__
OK
```