### PR TITLE
Add ubuntu-unused-kernels

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
   - apt::unattended_upgrades
+  - govuk_apt::unused_kernels
   - gds_accounts
   - harden
   - puppet

--- a/modules/govuk_apt/files/etc/cron.daily/remove_unused_kernels
+++ b/modules/govuk_apt/files/etc/cron.daily/remove_unused_kernels
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e -o pipefail
+
+PATH=/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ubuntu-unused-kernels | xargs -r apt-get -y purge

--- a/modules/govuk_apt/manifests/unused_kernels.pp
+++ b/modules/govuk_apt/manifests/unused_kernels.pp
@@ -1,0 +1,16 @@
+# Class: govuk_apt::unused_kernels
+#
+# Periodically remove packages for Ubuntu kernels that are no longer used in
+# order to reclaim disk space used.
+#
+class govuk_apt::unused_kernels {
+  package { 'ubuntu_unused_kernels':
+    ensure   => '0.2.0',
+    provider => 'gem',
+  } ->
+  file { '/etc/cron.daily/remove_unused_kernels':
+    ensure => present,
+    source => 'puppet:///modules/govuk_apt/etc/cron.daily/remove_unused_kernels',
+    mode   => '0755',
+  }
+}


### PR DESCRIPTION
This adds govuk-unused-kernels [1] to periodically clean up unused kernels before they eat all the disk. This is copied from GOV.UK puppet [2]  only changing the provider from `system_gem` to `gem`.

I have not pulled this out into a separate puppet module because I don't know what the process is. If that is something I should do it would be good if I could pair with someone on it.

I have tested this with Vagrant.

[1] https://github.com/gds-operations/ubuntu_unused_kernels
[2] https://github.gds/gds/puppet/tree/master/modules/govuk_apt