### PR TITLE
Update canary response

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -84,7 +84,7 @@ nginx::nginx_locations:
     location_custom_cfg:
       - 'default_type text/plain'
       - 'add_header cache-control "max-age=0, no-store, no-cache"'
-      - 'return 200 "OK\n"'
+      - 'return 200 "Mirror OK\n"'
 
 mirror_environment::supported_kernel::hwe_ver: 'trusty'
 


### PR DESCRIPTION
Making this more specific means that it's quicker for us to diagnose where this response is coming from compared to if it's just "OK".

We were seeing this response recently and nobody knew immediately that it was coming from the mirrors. We'd have a much better chance of figuring that out if this was the response.

I don't know of anywhere that we monitoring this response (maybe Pingdom?) but that will need updating when this is deployed.