### PR TITLE
Rotate SSH key for Matt Bostock

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -133,7 +133,7 @@ gds_accounts::accounts:
     ssh_key: replace-key-cve-2016-0777
   mattbostock:
     comment: Matt Bostock
-    ssh_key: replace-key-cve-2016-0777
+    ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAACAQDBc1Tcz6UiZoCnQCadVCSuJT9UXu0sf/duILN5epB2s0jL1uB8rKjT+RrpstZAr5YIN3Gm2IpTlTAxftNyDnxH5SqFYt4lLG+ibCxGffUYdJt0RCc4Atgh7VJDtLiwLbH1iaAVCipV8SevkcbT1BaBymsIPqy76XtuI46ENTbT23wW9a3F6j43M0TMzjFsTVy4dagSkkpb3V47E26jik/rcVL43lZNyaLBx/Nn/4bdGjZw6LfjyTAyE//xTvK5I6dYLFF4hH9IwC59Hs532q73YjXsEey4hf+mPjZWjirIJdyisXyK4E1LfKTqQoqOd2mMiPlK15pkDkHc1DnZTv8AZCgWNf87li2GIAsuB62bR76Umg7U49J+hFN6TSs8kLB+QJg83BBnKUb4lJj49BCGg7VP6xx7VIuG6ir/WROmN33miKpYBE8NYZb1t7W/CeglcfA3eZh+ZZAvQ8AUDh7WHvxqr0L5UQuuVCtO4pJV0OyKorLM/5TYh++CKr0Z+EZAVK3WsB+EIPbT9lNy0FrY40GAfE2Ud4uW5P20afYnd+f2TfBotRC6EHtM8guqO8JoFUqWTCgcyQyEe3f4zR5x7jseGyb/hL+dOPgfw3WNVYdLKNQx9weEjRAVhlzfDOrfOXEdPoaOYKmtWd2i4yM0/wblxOQnxI4rZbo1KWBx2Q==
   richardboulton:
     comment: Richard Boulton
     ssh_key: replace-key-cve-2016-0777


### PR DESCRIPTION
Due to CVE-0216-0778:
http://undeadly.org/cgi?action=article&sid=20160114142733