### PR TITLE
Add NRPE check_disk_mirror-data command

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -93,6 +93,8 @@ mirror_environment::supported_kernel::hwe_ver: 'trusty'
 mirror_environment::mounts::mirror_data: '/srv/mirror_data'
 mirror_environment::mounts::username: 'mirror-rsync'
 
+mirror_environment::nrpe::mirror_data_mountpoint: "%{hiera('mirror_environment::mounts::mirror_data')}"
+
 mirror_environment::user::username: 'mirror-rsync'
 mirror_environment::user::ssh_key: 'AAAAB3NzaC1yc2EAAAABIwAAAQEAw/ksvUhzrUVVbupDXEwz4J2K8Yz515pxhRLpfx6oGruM/hj4wVJ5uPt+4IL5k0sLXxRH0X/VXuK2zBV2fSnPP4cNUZiFrPbN1gea945dGvGIstLMZfsw8Md3jN4i8UXZFBriUfjQT7APLGEsQ+fl+Lzuhpp1nq2oWKem28moAxQkxU2ShPQhP/kzRkTrNbiusOFE4YQN4seZRJEtZ22p+qSVAPVyc2mfJHr6gdVNO3dMBdD7Ud9m3L5AeD7GNA/r2DiJViIplipRMvJJ0w3KkCnTWHiw3C0tXjyAMIH3jXqIJVqUej7Jum3FzixQrFgBR88XkPzlR0qHvR73HBSeZQ=='
 

--- a/modules/mirror_environment/manifests/nrpe.pp
+++ b/modules/mirror_environment/manifests/nrpe.pp
@@ -3,7 +3,7 @@
 # This class defines NRPE commands to be used with the pdxcat/nrpe module
 # this repository uses.
 
-class mirror_environment::nrpe{
+class mirror_environment::nrpe {
 
   nrpe::command {'check_disk':
     ensure  => present,

--- a/modules/mirror_environment/manifests/nrpe.pp
+++ b/modules/mirror_environment/manifests/nrpe.pp
@@ -9,4 +9,10 @@ class mirror_environment::nrpe {
     ensure  => present,
     command => 'check_disk -w 10% -c 5%',
   }
+
+  nrpe::command {'check_disk_mirror-data':
+    ensure  => present,
+    command => 'check_disk -w 10% -c 5% /srv/mirror_data',
+  }
+
 }

--- a/modules/mirror_environment/manifests/nrpe.pp
+++ b/modules/mirror_environment/manifests/nrpe.pp
@@ -5,8 +5,8 @@
 
 class mirror_environment::nrpe{
 
-    nrpe::command {'check_disk':
-        ensure  => present,
-        command => 'check_disk -w 10% -c 5%',
-    }
+  nrpe::command {'check_disk':
+    ensure  => present,
+    command => 'check_disk -w 10% -c 5%',
+  }
 }

--- a/modules/mirror_environment/manifests/nrpe.pp
+++ b/modules/mirror_environment/manifests/nrpe.pp
@@ -2,8 +2,16 @@
 #
 # This class defines NRPE commands to be used with the pdxcat/nrpe module
 # this repository uses.
+#
+# === Parameters
+#
+# [*mirror_data_mountpoint*]
+#   The mount point for the data that the mirrors serve.
+#
 
-class mirror_environment::nrpe {
+class mirror_environment::nrpe (
+  $mirror_data_mountpoint,
+){
 
   nrpe::command {'check_disk':
     ensure  => present,
@@ -12,7 +20,7 @@ class mirror_environment::nrpe {
 
   nrpe::command {'check_disk_mirror-data':
     ensure  => present,
-    command => 'check_disk -w 10% -c 5% /srv/mirror_data',
+    command => "check_disk -w 10% -c 5% ${mirror_data_mountpoint}",
   }
 
 }


### PR DESCRIPTION
Story: https://trello.com/c/3lN6luRf/94-disk-space-alerts-for-mirrors

Add an NRPE command that allows us to check the available disk space on
the filesystem mounted at `/srv/mirror_data`, in addition to the
existing check which checks disk space on all filesystems.