### PR TITLE
Revert "Refactor UFW config to use Hiera data"

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -10,6 +10,7 @@ classes:
   - mirror_environment::clamdscan
   - mirror_environment::cron
   - mirror_environment::fail2ban
+  - mirror_environment::firewall
   - mirror_environment::mounts
   - mirror_environment::nrpe
   - mirror_environment::supported_kernel
@@ -20,7 +21,6 @@ classes:
   - resolvconf
   - rssh
   - ssh::server
-  - ufw
 
 apt::unattended_upgrades::auto_reboot: true
 
@@ -145,14 +145,3 @@ gds_accounts::accounts:
   tombooth:
     comment: Tom Booth
     ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAACAQCXsr6ArkA8+cJaTBUnsdUmWbXevETDpJjwkIpG0QK7HsvVNZrTUbBqCnkq3S9RGmqwDEDomV6lwl6mcT7jfnX4t156l+lPGb6Bc3NLLLvzp5ezTM/HuCbsWrmppZeBV4u1rEOPB3mW97P1lm548LUVeb0lQmsR14VmHVHbTk+kQNRWn1Qw9eRAcoYfJZVFl3B2Gz4S/ASMm7ZkIRnaTmcZg4Pqu8n9fOpQLBF3bql1TZ/EWuQzt3FD2cFf/LsolxSd8Q7USsROkRCb9JnUAovxlMd5ac83aMgURVswzxq1CM6E042XmOMswjCZI1/ZRx2jJogH1UMeueXguZxvjYBbD3ixomtLW+4fsWCXg2dLgzZmGZAZIP619Gkqg2pCKDXRYpx0j2TmscJ53dUf9v1NU5vDThz4yCRN1o071ZSd4uBwonPvHINK3yOHOY7EnM/HjQnQQAFhdZiXKSJiOUM14bRH8vCsMYxr9ZJH3EDAR3U0Kra/uCnVjNGo5E7QS9BO+BOx8UBjE+RBOPNLSDvh1oDtnXNHULBntlXcJimtub/Z77ljnMDU8nPlacvKgCZFdsr5vxvIsvz0HT4U5ccSKABQNHkSdPYmOT0yCWolpHbIhjlt49NiFTCNqka951J9ygR9Tw4ptBOSNVEKp52iY2Y5qvxMjGx0uKZkXPcNyQ==
-
-ufw::allows:
-  ssh:
-    port: 22
-    ip: any
-  https:
-    port: 443
-    ip: any
-  nrpe:
-    port: 5666
-    ip: any

--- a/modules/mirror_environment/manifests/firewall.pp
+++ b/modules/mirror_environment/manifests/firewall.pp
@@ -1,0 +1,22 @@
+# == Class: mirror_environment::firewall
+#
+# Configures ufw
+#
+#
+class mirror_environment::firewall {
+
+  ufw::allow { 'allow-ssh':
+    port => '22',
+    ip   => 'any'
+  }
+
+  ufw::allow { 'allow-https':
+    port => '443',
+    ip   => 'any'
+  }
+
+  ufw::allow { 'allow-nrpe':
+    port => '5666',
+    ip   => 'any'
+  }
+}


### PR DESCRIPTION
This reverts commit e630081b9a857ef54686dec41d45eb50045fa03a.

The version of the ufw module that we're using in the Puppetfile doesn't support creation of resources using hieradata.