### PR TITLE
Re-include UFW class

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -21,6 +21,7 @@ classes:
   - resolvconf
   - rssh
   - ssh::server
+  - ufw
 
 apt::unattended_upgrades::auto_reboot: true
 


### PR DESCRIPTION
This used to be duplicated in this list but was accidentally removed in 2 separate commits when it should have only been removed once.