### PR TITLE
Upgrade facter from 1.7.2 to 1.7.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 
 # Puppet core.
 gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.1.0'
-gem 'facter', ENV['FACTER_VERSION'] || '~> 1.6.0'
+gem 'facter', '1.7.5'
 
 # Dependency management.
 gem 'librarian-puppet-maestrodev'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.4)
-    facter (1.6.18)
+    facter (1.7.5)
     hiera (1.2.1)
       json_pure
     highline (1.6.20)
@@ -46,7 +46,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  facter (~> 1.6.0)
+  facter (= 1.7.5)
   librarian-puppet-maestrodev
   puppet (~> 3.1.0)
   puppet-lint (~> 0.3.0)

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -25,7 +25,7 @@ classes:
 apt::unattended_upgrades::auto_reboot: true
 
 puppet::puppet_ensure: '3.2.3-1puppetlabs1'
-puppet::facter_ensure: '1.7.2-1puppetlabs1'
+puppet::facter_ensure: '1.7.5-1puppetlabs1'
 puppet::cron_command: '/opt/puppet/tools/puppet-apply --environment %{environment}'
 puppet::cron_ensure: 'present'
 


### PR DESCRIPTION
1.7.2 is no longer available in the apt repo.

https://docs.puppet.com/facter/1.7/release_notes.html