### PR TITLE
Add nginx location blocks for errors

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -86,6 +86,19 @@ nginx::nginx_locations:
       - 'default_type text/plain'
       - 'add_header cache-control "max-age=0, no-store, no-cache"'
       - 'return 200 "Mirror OK\n"'
+  'error-www':
+    vhost: 'www-origin'
+    priority: 900
+    location: '= /error/503.html'
+    location_custom_cfg:
+      - 'root /srv/mirror_data'
+  'error-assets':
+    vhost: 'assets-origin'
+    priority: 900
+    location: '= /error/503.html'
+    location_custom_cfg:
+      - 'root /srv/mirror_data'
+
 
 nrpe::allowed_hosts:
   - 127.0.0.1


### PR DESCRIPTION
The existing errors from `/error/503.html` don't work because the error directory isn't inside the `www_root`, it's one level higher up (in `/srv/mirror_data`).

This commit adds location blocks for the 2 vhosts so that requests to `/error/503.html` are served from the root directory. This means that the file that ends up being served is `/srv/mirror_data/error/503.html`.